### PR TITLE
Added comparison tool for different ASW

### DIFF
--- a/a2lbincompare.py
+++ b/a2lbincompare.py
@@ -3,11 +3,22 @@ from pya2l.api import inspect
 from sys import argv
 
 db = DB()
+db2 = DB()
 # session = db.import_a2l(argv[1])
+
+# CLI arguments: a2lbincompare.py [first_a2l] [first_bin] [second_a2l] [second_bin] [search_term?]
+
+# First A2L & bin
 session = db.open_existing(argv[1])
 data1 = open(argv[2], "rb").read()
-data2 = open(argv[3], "rb").read()
 
+# Second A2L & bin
+session2 = db2.open_existing(argv[3])
+data2 = open(argv[4], "rb").read()
+
+search_term = (
+    argv[5] if len(argv) > 5 else None
+)
 
 def calc_map_size(characteristic):
     data_sizes = {
@@ -29,20 +40,36 @@ def calc_map_size(characteristic):
 characteristics = (
     session.query(model.Characteristic).order_by(model.Characteristic.name).all()
 )
+
 for c in characteristics:
-    # print(inspect.Characteristic(session, c.name))
+    if search_term and (search_term not in (c.name+c.longIdentifier)):
+        # Characteristic does not meet search term, continue
+        continue
+
+    # Get characteristic from both A2Ls, using the name from the first one
     characteristic_data = inspect.Characteristic(session, c.name)
+    try:
+        characteristic_data2 = inspect.Characteristic(session2, c.name)
+    except:
+        continue
+        # print(c.name + " does not exist in: "+argv[3])
+
+    # Get the map size (should be the same but best to double check)
     map_size = calc_map_size(characteristic_data)
+    map_size2 = calc_map_size(characteristic_data2)
+
+    # Get offset
     offset = characteristic_data.address - 0xA0800000
+    offset2 = characteristic_data2.address - 0xA0800000
+
+    # Get data from bin
     data1_map = data1[offset : offset + map_size]
-    data2_map = data2[offset : offset + map_size]
+    data2_map = data2[offset2 : offset2 + map_size2]
+
+    # Check match
     is_match = data1_map == data2_map
+
     if not is_match:
         print(
             characteristic_data.name + " : " + characteristic_data.longIdentifier
         )  #  " @ " + hex(offset) + ":" + hex(offset+map_size) +
-
-# measurements = session.query(model.Measurement).order_by(model.Measurement.name).all()
-# for m in measurements:
-#    print(inspect.Measurement(session, m.name))
-#    print(inspect.CompuMethod(session, m.conversion))


### PR DESCRIPTION
Decided to overwrite the original compare tool, not sure if it's really necessary if you have an XDF and access to TunerPro when comparing the same ASW?

Also added in an optional search term argument to fine tune results.

New command structure: a2lbincompare.py [first_a2l] [first_bin] [second_a2l] [second_bin] [search_term?]

May rewrite it at some point to reduce code reuse but is functional for the time being. Will be adding text output in the future, a matches.txt & differences.txt will be generated once it's complete.